### PR TITLE
TWON-16318: Remove libsdl2-mixer-dev and libsdl2-ttf-dev

### DIFF
--- a/make_var_mx6ul_dart_debian.sh
+++ b/make_var_mx6ul_dart_debian.sh
@@ -86,7 +86,7 @@ readonly G_EXT_CROSS_COMPILER_LINK="http://releases.linaro.org/components/toolch
 
 ############## user rootfs packages ##########
 #We need the binaries to make it run, but we need the *dev packages to compile it. Maybe we can split into two packages types: rootfs and sysroot
-readonly G_USER_PACKAGES="minicom tree bash-completion libc6 gdbserver libelf1 libdw1 libelf-dev libdw-dev uuid-dev libssl-dev libstdc++-4.9-dev libsdl1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libcurl4-gnutls-dev libapt-pkg-dev libiw-dev libnm-glib-dev libdbus-glib-1-dev libglib2.0-dev libbluetooth-dev libreadline-dev libxi-dev libxinerama-dev libxcursor-dev libxrandr-dev libudev-dev libusb-dev libibus-1.0-dev evtest libjack-dev libgbm-dev libmad0 libsdl2-mixer-dev libfuse2 fuse exfat-fuse exfat-utils ntfs-3g libevdev2 libsdl2-ttf-dev"
+readonly G_USER_PACKAGES="minicom tree bash-completion libc6 gdbserver libelf1 libdw1 libelf-dev libdw-dev uuid-dev libssl-dev libstdc++-4.9-dev libsdl1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libcurl4-gnutls-dev libapt-pkg-dev libiw-dev libnm-glib-dev libdbus-glib-1-dev libglib2.0-dev libbluetooth-dev libreadline-dev libxi-dev libxinerama-dev libxcursor-dev libxrandr-dev libudev-dev libusb-dev libibus-1.0-dev evtest libjack-dev libgbm-dev libmad0 libfuse2 fuse exfat-fuse exfat-utils ntfs-3g libevdev2"
 
 #### Input params #####
 PARAM_DEB_LOCAL_MIRROR="${DEF_DEBIAN_MIRROR}"


### PR DESCRIPTION
Currently we have a custom version for twonav-sdl2-2.0-0 (2.0.9+twonav2).
As libsdl2-ttf-dev and libsdl2-mixer-dev depends on libsdl2-2.0-0=2.0.2+dfsg1-6, after first installation of TwoNav, apt gets broken:

```
You might want to run 'apt-get -f install' to correct these:
The following packages have unmet dependencies:
 libsdl2-dev : Depends: libsdl2-2.0-0 (= 2.0.2+dfsg1-6) but 2.0.9+twonav2 is to be installed
 libxrandr-dev : Depends: libxrandr2 (= 2:1.4.2-1+deb8u1) but 2:1.5.0-1+twonav1~deb8u1 is to be installed
 twonav-aventura-2018 : PreDepends: twonav-system-2018 (= 1.0.1) but 1.0.2 is to be installed
E: Unmet dependencies. Try 'apt-get -f install' with no packages (or specify a solution).
```

To solve this, I've removed **libsdl2-ttf-dev** and **libsdl2-mixer-dev**.
