### PR TITLE
TWON-16318: Solve unmet dependencies and preinstall TwoNav

### DIFF
--- a/make_var_mx6ul_dart_debian.sh
+++ b/make_var_mx6ul_dart_debian.sh
@@ -1147,12 +1147,6 @@ function cmd_make_rootfs() {
 		return 1;
 	};
 
-	## pack rootfs
-	make_tarbar ${G_ROOTFS_DIR} ${G_ROOTFS_TARBAR_PATH} || {
-		pr_error "Failed #$? in function make_tarbar"
-		return 4;
-	}
-
 	## pack to ubi
 	make_ubi ${G_ROOTFS_DIR} ${G_TMP_DIR} ${PARAM_OUTPUT_DIR} ${G_UBI_FILE_NAME}  || {
 		pr_error "Failed #$? in function make_ubi"

--- a/make_var_mx6ul_dart_debian.sh
+++ b/make_var_mx6ul_dart_debian.sh
@@ -547,31 +547,37 @@ echo "#!/bin/bash
 apt-get update
 
 # install all user packages
+echo -e \"${BACKGROUND_GREEN} Installing USER_PACKAGES... ${BACKGROUND_BLACK}\"
 apt-get -y --force-yes install ${G_USER_PACKAGES}
 if [ \$? -gt 0 ]; then
 	echo -e \"${BACKGROUND_RED} ERROR in apt-get install USER_PACKAGES ${BACKGROUND_BLACK}\"
 fi
 
+echo -e \"${BACKGROUND_GREEN} Installing EXTRAS_PACKAGES... ${BACKGROUND_BLACK}\"
 apt-get -y --force-yes install ${G_EXTRAS_PACKAGES}
 if [ \$? -gt 0 ]; then
 	echo -e \"${BACKGROUND_RED} ERROR in apt-get install EXTRAS_PACKAGES ${BACKGROUND_BLACK}\"
 fi
 
+echo -e \"${BACKGROUND_GREEN} Purging KERNEL_PACKAGES... ${BACKGROUND_BLACK}\"
 apt-get -y --force-yes purge ${G_KERNEL_PACKAGES}
 if [ \$? -gt 0 ]; then
 	echo -e \"${BACKGROUND_RED} ERROR in apt-get purge KERNEL_PACKAGES ${BACKGROUND_BLACK}\"
 fi
 
-#rm -rf /lib/modules/4.1.15-twonav-aventura-2018
-apt-get -y --force-yes install ${G_KERNEL_PACKAGES}
+echo -e \"${BACKGROUND_GREEN} Installing KERNEL_PACKAGES... ${BACKGROUND_BLACK}\"
+DEBIAN_FRONTEND=noninteractive apt-get -y --force-yes install ${G_KERNEL_PACKAGES}
 if [ \$? -gt 0 ]; then
 	echo -e \"${BACKGROUND_RED} ERROR in apt-get install KERNEL_PACKAGES ${BACKGROUND_BLACK}\"
 fi
 
+echo -e \"${BACKGROUND_GREEN} Installing TWONAV_PACKAGES... ${BACKGROUND_BLACK}\"
 apt-get -y --force-yes install ${G_TWONAV_PACKAGES}
 if [ \$? -gt 0 ]; then
 	echo -e \"${BACKGROUND_RED} ERROR in apt-get install TWONAV_PACKAGES ${BACKGROUND_BLACK}\"
 fi
+
+echo -e \"${BACKGROUND_GREEN} SUCCESS user-stage ${BACKGROUND_BLACK}\"
 
 rm -f user-stage
 " > user-stage

--- a/make_var_mx6ul_dart_debian.sh
+++ b/make_var_mx6ul_dart_debian.sh
@@ -394,15 +394,15 @@ function protected_install() {
 
     for (( c=0; c<\${repeated_cnt}; c++ ))
     do
-        apt-get install -y \${_name} && {
+        apt-get install -y --force-yes \${_name} && {
             RET_CODE=0;
             break;
         };
 
         echo ""
-        echo "###########################"
-        echo "## Fix missing packages ###"
-        echo "###########################"
+        echo "##################################"
+        echo "## Fix missing packages \${_name} ###"
+        echo "##################################"
         echo ""
 
         sleep 2;
@@ -544,7 +544,6 @@ apt-get update
 apt-get -y install ${G_USER_PACKAGES}
 
 apt-get -y --force-yes install ${G_EXTRAS_PACKAGES}
-rm -rf /lib/modules/4.1.15-twonav-aventura-2018/
 DEBIAN_FRONTEND=noninteractive apt-get -y --force-yes install ${G_KERNEL_PACKAGES}
 apt-get -y --force-yes install ${G_TWONAV_PACKAGES}
 

--- a/make_var_mx6ul_dart_debian.sh
+++ b/make_var_mx6ul_dart_debian.sh
@@ -86,9 +86,9 @@ readonly G_EXT_CROSS_COMPILER_LINK="http://releases.linaro.org/components/toolch
 
 ############## user rootfs packages ##########
 #We need the binaries to make it run, but we need the *dev packages to compile it. Maybe we can split into two packages types: rootfs and sysroot
-readonly G_USER_PACKAGES="minicom tree bash-completion libc6 gdbserver libelf1 libdw1 libelf-dev libdw-dev uuid-dev libssl-dev libstdc++-4.9-dev libsdl1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libcurl4-gnutls-dev libapt-pkg-dev libiw-dev libnm-glib-dev libdbus-glib-1-dev libglib2.0-dev libbluetooth-dev libreadline-dev libxi-dev libxinerama-dev libxcursor-dev libudev-dev libusb-dev libibus-1.0-dev evtest libjack-dev libgbm-dev libmad0 libfuse2 fuse exfat-fuse exfat-utils ntfs-3g libevdev2"
+readonly G_USER_PACKAGES="minicom tree bash-completion libc6 gdbserver libelf1 libdw1 libelf-dev libdw-dev uuid-dev libssl-dev libstdc++-4.9-dev libsdl1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libcurl4-gnutls-dev libapt-pkg-dev libiw-dev libnm-glib-dev libdbus-glib-1-dev libglib2.0-dev libbluetooth-dev libreadline-dev libxi-dev libxinerama-dev libxcursor-dev libudev-dev libusb-dev libibus-1.0-dev evtest libjack-dev libgbm-dev libmad0 libfuse2 fuse exfat-fuse exfat-utils ntfs-3g libevdev2 libsdl2-ttf-dev libsdl2-mixer-dev"
 
-readonly G_EXTRA_PACKAGES="ttf-ubuntu-font-family libsdl2-2.0-0 libsdl2-dev libsdl2-ttf-2.0-0 libxrandr2 xserver-xorg-input-evdev twonav-libraries twonav-compeplugins twonav-datumgrids twonav-factoryutils twonav-libamazonutilities twonav-sounds twonav-system-2018"
+readonly G_EXTRAS_PACKAGES="ttf-ubuntu-font-family libsdl2-2.0-0 libsdl2-dev libsdl2-ttf-2.0-0 libxrandr2 xserver-xorg-input-evdev twonav-libraries twonav-compeplugins twonav-datumgrids twonav-factoryutils twonav-libamazonutilities twonav-sounds twonav-system-2018"
 
 readonly G_KERNEL_PACKAGES="linux-headers-4.1.15-twonav-aventura-2018 linux-image-4.1.15-twonav-aventura-2018"
 

--- a/make_var_mx6ul_dart_debian.sh
+++ b/make_var_mx6ul_dart_debian.sh
@@ -86,7 +86,7 @@ readonly G_EXT_CROSS_COMPILER_LINK="http://releases.linaro.org/components/toolch
 
 ############## user rootfs packages ##########
 #We need the binaries to make it run, but we need the *dev packages to compile it. Maybe we can split into two packages types: rootfs and sysroot
-readonly G_USER_PACKAGES="minicom tree bash-completion libc6 gdbserver libelf1 libdw1 libelf-dev libdw-dev uuid-dev libssl-dev libstdc++-4.9-dev libsdl1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libcurl4-gnutls-dev libapt-pkg-dev libiw-dev libnm-glib-dev libdbus-glib-1-dev libglib2.0-dev libbluetooth-dev libreadline-dev libxi-dev libxinerama-dev libxcursor-dev libxrandr-dev libudev-dev libusb-dev libibus-1.0-dev evtest libjack-dev libgbm-dev libmad0 libsdl2-mixer-dev libfuse2 fuse exfat-fuse exfat-utils ntfs-3g libevdev2 libsdl2-ttf-dev"
+readonly G_USER_PACKAGES="minicom tree bash-completion libc6 gdbserver libelf1 libdw1 libelf-dev libdw-dev uuid-dev libssl-dev libstdc++-4.9-dev libsdl1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libcurl4-gnutls-dev libapt-pkg-dev libiw-dev libnm-glib-dev libdbus-glib-1-dev libglib2.0-dev libbluetooth-dev libreadline-dev libxi-dev libxinerama-dev libxcursor-dev libxrandr-dev libudev-dev libusb-dev libibus-1.0-dev evtest libjack-dev libgbm-dev libmad0 libfuse2 fuse exfat-fuse exfat-utils ntfs-3g libevdev2"
 
 #### Input params #####
 PARAM_DEB_LOCAL_MIRROR="${DEF_DEBIAN_MIRROR}"


### PR DESCRIPTION
El siguiente PR lo cancelé:
https://github.com/twonav/debian-var/pull/19

aunque me lié un poco en el diagnóstico. 

El diagnóstico es el siguiente:
**libsdl2-dev** del repo oficial Jessie depende de **libsdl2-2.0-0 = 2.0.2+dfsg1-6**, pero como tenemos la versión custom **libsdl2-2.0-0 = 2.0.9+twonav2** tenemos el "unmet dependencies".

Así que ahora se ha hecho que se generen los 2 paquetes de nuestro repo: **libsdl2-2.0-0** + **libsdl2-dev** (ver https://bitbucket.org/compegps/twonav-sdl2/pull-requests/12/twon-16318-generate-libsdl2-20-0-and/diff).

También se ha eliminado **libxrandr-dev**, ya que depende explícitamente de **libxrandr2 (= 2:1.4.2-1+deb8u1)**, que es la versión **jessie** y nosotros tenemos la versión custom **libxrandr2 (= 2:1.5.0-1+twonav1~deb8u1)**

Otras mejoras incluídas en este PR son:
- Preinstalar twonav+kernel+extras según el canal **CompeGPS_Channels/Product2018/iMX6Beta**
- Problemas en la función **protected_install**, era necesario añadir un **force_yes** para instalar **Xorg**, 
**network-manager-gnome**, **audacious**, aparentemente por tener dependencias de paquetes que no pueden ser autenticados (quizá es un tema a revisar):
`WARNING: The following packages cannot be authenticated!
  libxrandr2 xserver-xorg-input-evdev`
- En la imagen final, el **sources.list** queda con el repo a jessie comentado y con el **sources.list.d/twonav.list** correspondiente
