### PR TITLE
VRF-34: Mfgtool for beta2

### DIFF
--- a/make_var_mx6ul_dart_debian.sh
+++ b/make_var_mx6ul_dart_debian.sh
@@ -352,9 +352,9 @@ function make_debian_rootfs() {
 echo "deb $PARAM_DEB_LOCAL_MIRROR ${DEB_RELEASE} main contrib non-free
 " > etc/apt/sources.list
 
-echo "deb http://apt.twonav.com/ CompeGPS_Channels/Product2018/iMX6Beta/TwoNav/" >> etc/apt/sources.list.d/twonav.list
-echo "deb http://apt.twonav.com/ CompeGPS_Channels/Product2018/iMX6Beta/Kernel/" >> etc/apt/sources.list.d/twonav.list
-echo "deb http://apt.twonav.com/ CompeGPS_Channels/Product2018/iMX6Beta/Extras/" >> etc/apt/sources.list.d/twonav.list
+echo "deb http://apt.twonav.com/ CompeGPS_Channels/Product2018/Beta/TwoNav/" >> etc/apt/sources.list.d/twonav.list
+echo "deb http://apt.twonav.com/ CompeGPS_Channels/Product2018/Beta/Kernel/" >> etc/apt/sources.list.d/twonav.list
+echo "deb http://apt.twonav.com/ CompeGPS_Channels/Product2018/Beta/Extras/" >> etc/apt/sources.list.d/twonav.list
 
 echo "
 # /dev/mmcblk0p1  /boot           vfat    defaults        0       0


### PR DESCRIPTION
Change APT channel to **Beta**.
After the "big merge" iMX6Beta => Development (https://jira.compegps.com/browse/TWON-16073), we forget to change the APT channel when generating new rootfs images.

In order to generate more stable and controlled images, I change to **Beta** (instead of **Development**).